### PR TITLE
Enable Model Caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] (alpha)
+
+### Added
+
+- Model Caching: Persisting model files in WebWorker's cache to avoid re-downloading model on every load. Thanks to [PR](https://github.com/rahuldshetty/llm.js/pull/3) from [@felladrin](https://github.com/felladrin). 
 
 ## [1.0.2]
 

--- a/src/utility.js
+++ b/src/utility.js
@@ -1,8 +1,13 @@
-export async function loadBinaryResource(url, callback) {
-    let cache = null;
+const cacheName = "llm.js-cache";
 
-    if (window.caches) {
-        const cacheName = "llm.js-cache";
+export async function loadBinaryResource(url, callback) {
+    let cache = null, window = self;
+
+    // Try to find if the model data is cached in Web Worker memory.
+    if (typeof window === "undefined") {
+        console.log("Oops, `window` is not defined")
+    }
+    else if(window && window.caches) {
         cache = await window.caches.open(cacheName);
         const cachedResponse = await cache.match(url);
 
@@ -18,7 +23,7 @@ export async function loadBinaryResource(url, callback) {
     req.open("GET", url, true);
     req.responseType = "arraybuffer";
 
-    req.onload = async () => {
+    req.onload = async (_) => {
         const arrayBuffer = req.response; // Note: not req.responseText
         if (arrayBuffer) {
             const byteArray = new Uint8Array(arrayBuffer);


### PR DESCRIPTION
## Added

- Persisting model files in WebWorker's cache to avoid re-downloading model on every load. Thanks to [PR](https://github.com/rahuldshetty/llm.js/pull/3) from [@felladrin](https://github.com/felladrin). 
